### PR TITLE
Changes to Documentation and Information

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -25,9 +25,9 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 ### 
 #
 ### Contributing Process
-When making contributions, please follow the steps below. For a list of open issues, please [click here](https://github.com/JohnCoene/coronavirus/issues),
+When making contributions, please follow the steps below. For a list of open issues, please [click here](https://github.com/JohnCoene/coronavirus/issues).
 
- 1. [Copy the project repository](https://github.com/JohnCoene/coronavirus/fork/) (i.e, make a copy of all of the project code)
+ 1. [Copy the project repository](https://github.com/JohnCoene/coronavirus/fork/) 
 2.  Create a new branch for your feature 
   `git checkout -b feature/MyFeature`
 3. Edit the code in your feature as you'd like

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,53 @@
+<div align="center">
+
+<img src="./man/figures/logo.png" height="250px" />
+
+<!-- badges: start -->
+[![CircleCI build status](https://circleci.com/gh/JohnCoene/coronavirus.svg?style=svg)](https://circleci.com/gh/JohnCoene/coronavirus)
+[![Travis build status](https://travis-ci.org/JohnCoene/coronavirus.svg?branch=master)](https://travis-ci.org/JohnCoene/coronavirus)
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/JohnCoene/coronavirus?branch=master&svg=true)](https://ci.appveyor.com/project/JohnCoene/coronavirus)
+![R-CMD-check](https://github.com/JohnCoene/coronavirus/workflows/R-CMD-check/badge.svg)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
+![](https://img.shields.io/badge/license-MIT-blue)
+<!-- badges: end -->
+
+Dashboard to track the spread of the coronavirus, based on three data sources, built with [shinyMobile](https://rinterface.github.io/shinyMobile/) and [echarts4r](https://echarts4r.john-coene.com/).
+
+[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFO.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
+
+</div>
+
+## Contribute
+Below is all of the information needed to get started as a contributor to the project. 
+#
+### Contributor Code of Conduct
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/JohnCoene/coronavirus/blob/master/CODE_OF_CONDUCT.md). By contributing to this project, you agree to abide by its terms.
+### 
+#
+### Contributing Process
+When making contributions, please follow the steps below. For a list of open issues, please [click here](https://github.com/JohnCoene/coronavirus/issues),
+
+ 1. [Copy the project repository](https://github.com/JohnCoene/coronavirus/fork/) (i.e, make a copy of all of the project code)
+2.  Create a new branch for your feature 
+  `git checkout -b feature/MyFeature`
+3. Edit the code in your feature as you'd like
+4.  Commit the changes you made to your feature 
+     `git commit -m 'Made these edits to MyFeature'`
+5.  Push to the feature branch 
+     `git push origin feature/MyFeature`
+7.  Open a [Pull Request](https://github.com/JohnCoene/coronavirus/compare). If this is your first time submitting a pull request, we recommend [this quick read](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) about the process.
+
+#
+### Coding Guidelines
+This project follows [Google's R style guide](http://web.stanford.edu/class/cs109l/unrestricted/resources/google-style.html). We ask that contributors please follow these coding guidelines.
+#
+### License
+#### MIT License
+
+Copyright (c) 2020 John Coene
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -13,7 +13,7 @@
 
 Dashboard to track the spread of the coronavirus, based on three data sources, built with [shinyMobile](https://rinterface.github.io/shinyMobile/) and [echarts4r](https://echarts4r.john-coene.com/).
 
-[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFO.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
+[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFORMATION.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
 
 </div>
 

--- a/GETSTARTED.md
+++ b/GETSTARTED.md
@@ -1,0 +1,110 @@
+<div align="center">
+
+<img src="./man/figures/logo.png" height="250px" />
+
+<!-- badges: start -->
+[![CircleCI build status](https://circleci.com/gh/JohnCoene/coronavirus.svg?style=svg)](https://circleci.com/gh/JohnCoene/coronavirus)
+[![Travis build status](https://travis-ci.org/JohnCoene/coronavirus.svg?branch=master)](https://travis-ci.org/JohnCoene/coronavirus)
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/JohnCoene/coronavirus?branch=master&svg=true)](https://ci.appveyor.com/project/JohnCoene/coronavirus)
+![R-CMD-check](https://github.com/JohnCoene/coronavirus/workflows/R-CMD-check/badge.svg)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
+![](https://img.shields.io/badge/license-MIT-blue)
+<!-- badges: end -->
+
+Dashboard to track the spread of the coronavirus, based on three data sources, built with [shinyMobile](https://rinterface.github.io/shinyMobile/) and [echarts4r](https://echarts4r.john-coene.com/).
+
+[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFO.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
+
+</div>
+
+## Getting Started
+
+Below is a step-by-step guide to getting your own iteration of the Coronavirus Tracker project set up on your local machine. 
+#### Requirements to get started:
+
+ - Install R (an IDE, such as RStudio, is also highly recommended) 
+ - Install the latest version of the `remotes` and `shinyMobile` packages
+
+### 1. Install the "coronavirus" package
+The tracker is installed via a package called **coronavirus**. You can download and install the package from github using `remotes`:
+
+    remotes::install_github("JohnCoene/coronavirus")
+
+### 2. Test that the app deploys correctly
+Deploying the app is very simple. Simply load the `coronavirus` package and run the `run_app()` command:
+
+    library(coronavirus)
+    
+    virus <- crawl_coronavirus()
+    run_app(virus)
+The app should deploy in a new window and display the same as the [web version](https://shiny.john-coene.com/coronavirus).
+
+#
+**After step 2, you are able to run your own LOCAL iteration of the tracker. If you wish to deploy your own iteration, please continue through the steps below.**
+#
+
+### 3. Create a Postgres Database
+In order to deploy your own iteration of the tracker, you will need to create a Postgres database. If you do not have a Postgres account, you can get started with one [here](https://www.postgresql.org/) for free. 
+
+### 4. Get a NewsAPI Token
+If you wish to incorporate news article sinto your iteration of the projectm you will need a NewsAPI token. You can get one for free [here]([newsapi.org](https://newsapi.org)).
+
+### 5. Create a Crawler Config File
+You will need to create a configuration file in order to run the crawler. *This only needs to be done once.* Run the following code to create the file:
+
+    library(coronavirus)
+    
+    create_config()
+
+### 6. Fill the Config File
+Fill in the config file created with the credentials to a Postgres database and the optional [NewsAPI](https://newsapi.org) token. Then, run the crawler. The config file should look like this:
+
+    database:
+        name: database-name
+        host: 123.123.123.12
+        user: me
+        password: my-password
+    newsapi:
+        key: xxXx6X43X12YXx4Xx0XxXx7y # from newsapi.org
+
+Every time you want to update the data, re-run `crawl_coronavirus`; it collects fresh data and overwrites all existing data.
+
+    crawl_coronavirus()
+    
+ ### 7. Deploy
+ 
+ #### Using Docker (recommended)
+ 
+ ##### 1. Pull the container
+ 
+    docker pull jcoenep/corona
+ ##### 2. Copy the config file to the container
+ 
+    docker run -v "$(pwd)"/_coronavirus.yml:/_coronavirus.yml -p 3000:80 jcoenep/corona
+    
+##### 3. Visit the site locally
+
+    localhost:3000
+
+ #### Using R
+
+##### 1. Deploy on a Shiny community server
+
+    sudo su - -c "R -e \"install.packages('remotes')\""
+    sudo su - -c "R -e \"remotes::install_github('JohnCoene/coronavirus')\""
+
+##### 2. Create the config file and store it under a directory called `/srv/shiny-server/`
+
+    cd /srv/shiny-server
+    mkdir coronavirus
+    cd ./coronavirus
+    R -e "coronavirus::create_config()"
+    vi _coronavirus.yml
+
+##### 3. Fill in the config file and create the Shiny app
+
+    echo "coronavirus::run_app()" > app.R 
+##### 4. Visit the site at ``http://my.server.ip:3838/coronavirus``
+Note that you can change the port in the `/etc/shiny-server/shiny-server.conf` file to `80` in order to to have your app hosted at `http://my.server.ip/coronavirus`.
+#
+Please see the [information](INFO.md) section for instruction on how to refresh data and embed charts.

--- a/GETSTARTED.md
+++ b/GETSTARTED.md
@@ -13,7 +13,7 @@
 
 Dashboard to track the spread of the coronavirus, based on three data sources, built with [shinyMobile](https://rinterface.github.io/shinyMobile/) and [echarts4r](https://echarts4r.john-coene.com/).
 
-[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFO.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
+[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFORMATION.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
 
 </div>
 
@@ -107,4 +107,4 @@ Every time you want to update the data, re-run `crawl_coronavirus`; it collects 
 ##### 4. Visit the site at ``http://my.server.ip:3838/coronavirus``
 Note that you can change the port in the `/etc/shiny-server/shiny-server.conf` file to `80` in order to to have your app hosted at `http://my.server.ip/coronavirus`.
 #
-Please see the [information](INFO.md) section for instructions on how to refresh data and embed charts.
+Please see the [information](INFORMATION.md) section for instructions on how to refresh data and embed charts.

--- a/GETSTARTED.md
+++ b/GETSTARTED.md
@@ -47,7 +47,7 @@ The app should deploy in a new window and display the same as the [web version](
 In order to deploy your own iteration of the tracker, you will need to create a Postgres database. If you do not have a Postgres account, you can get started with one [here](https://www.postgresql.org/) for free. 
 
 ### 4. Get a NewsAPI Token
-If you wish to incorporate news article sinto your iteration of the projectm you will need a NewsAPI token. You can get one for free [here]([newsapi.org](https://newsapi.org)).
+If you wish to incorporate news article sinto your iteration of the project, you will need a NewsAPI token. You can get one for free [here]([newsapi.org](https://newsapi.org)).
 
 ### 5. Create a Crawler Config File
 You will need to create a configuration file in order to run the crawler. *This only needs to be done once.* Run the following code to create the file:
@@ -107,4 +107,4 @@ Every time you want to update the data, re-run `crawl_coronavirus`; it collects 
 ##### 4. Visit the site at ``http://my.server.ip:3838/coronavirus``
 Note that you can change the port in the `/etc/shiny-server/shiny-server.conf` file to `80` in order to to have your app hosted at `http://my.server.ip/coronavirus`.
 #
-Please see the [information](INFO.md) section for instruction on how to refresh data and embed charts.
+Please see the [information](INFO.md) section for instructions on how to refresh data and embed charts.

--- a/INFORMATION.md
+++ b/INFORMATION.md
@@ -19,7 +19,7 @@ Dashboard to track the spread of the coronavirus, based on three data sources, b
 
 ## Information
 
-Below is a collection of information on dat and how to embed charts. 
+Below is a collection of information on data and how to embed charts. 
 
  - If you need guidance on how to get the tracker up and running, please see the [Getting Started](GETSTARTED.md) page.
  - If you need information on the overarching goals of the project, please see the [Home](README.md) page. 
@@ -80,7 +80,7 @@ Below is a list of corrected inaccuracies pertaining to the datasets used:
 
 `v0.1.1`
 
--   There was an issue were the number of cases counted in the John Hopkins map of china and world map was wrongly filtered and gave numbers higher than actually are.
+-   There was an issue where the number of cases counted in the John Hopkins map of China and world map was wrongly filtered and gave numbers higher than actually are.
 
 `v0.0.6`
 

--- a/INFORMATION.md
+++ b/INFORMATION.md
@@ -1,0 +1,93 @@
+<div align="center">
+
+<img src="./man/figures/logo.png" height="250px" />
+
+<!-- badges: start -->
+[![CircleCI build status](https://circleci.com/gh/JohnCoene/coronavirus.svg?style=svg)](https://circleci.com/gh/JohnCoene/coronavirus)
+[![Travis build status](https://travis-ci.org/JohnCoene/coronavirus.svg?branch=master)](https://travis-ci.org/JohnCoene/coronavirus)
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/JohnCoene/coronavirus?branch=master&svg=true)](https://ci.appveyor.com/project/JohnCoene/coronavirus)
+![R-CMD-check](https://github.com/JohnCoene/coronavirus/workflows/R-CMD-check/badge.svg)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
+![](https://img.shields.io/badge/license-MIT-blue)
+<!-- badges: end -->
+
+Dashboard to track the spread of the coronavirus, based on three data sources, built with [shinyMobile](https://rinterface.github.io/shinyMobile/) and [echarts4r](https://echarts4r.john-coene.com/).
+
+[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFO.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
+
+</div>
+
+## Information
+
+Below is a collection of information on dat and how to embed charts. 
+
+ - If you need guidance on how to get the tracker up and running, please see the [Getting Started](GETSTARTED.md) page.
+ - If you need information on the overarching goals of the project, please see the [Home](README.md) page. 
+ - If you'd like to know how to contribute to the project, please see the [Contribute](CONTRIBUTE.md) page.
+
+## Embedding Charts
+#### Requirements to get started:
+
+ - A Postgres database setup (also needed for API deployment)
+ - The config file used to deploy the API locally (please see the [Getting Started](GETSTARTED.md) page for specific instructions)
+
+Embedded charts are hosted in a separate shiny application which can optionally be deployed on your own server too. The `run_app` function takes an `embed_url` argument which defaults to `https://shiny.john-coene/coronavirus-embed`, but can be changed to your own if you choose to deploy the embedded chart API.
+#### 1. Copy your config file and create a new directory on your server
+
+    echo "coronavirus::run_embeds()" > app.R 
+    
+#### 2. Run the app using the new directory URL (see below)
+
+    run_app(embed_url = "http://my-server.com/name-of-directory")
+
+## Data
+#### Sources
+
+ - Data from [John Hopkins GIS dashboard](https://github.com/CSSEGISandData/2019-nCoV) accessed via readr (used to be from Google sheet)
+ - Data from Weixin using the [nCov2019](https://github.com/GuangchuangYu/nCov2019) package thanks to Guangchuang Yu
+ - Data from [DingXiangYuan](https://ncov.dxy.cn/ncovh5/view/pneumonia) scraped using rvest.
+
+### Data Refresh Cron Job Setup
+If you wish to automatically refresh the data on your iteration of the API, below are instructions on how to set up a cron job to do this for you.
+
+#### 1. Recreate your config file in your home directory
+For guidance on how to set up your config file, please see the [Getting Started](GETSTARTED.md) page.
+
+    cd /home
+    mkdir ncov
+    R -e "coronavirus::create_config()"
+    vi _coronavirus.yml
+ 
+#### 2. Call `create_script()`
+The `create_script()` function will edit the config file to make it suitable for crawling fresh data.
+
+    R -e "coronavirus::create_script()"
+This will create a file called `script.R` in your current working directory.
+
+#### 3. Test the crawler
+Run the newly created script from the terminal to test that it works
+
+    Rscript script.R
+#### 4. Create the cron job
+Edit your cron jobs by calling `crontab -e` from your terminal. Then, insert your new job. We have the job below set up to run every hour, but you can change this interval to whatever you would like. We recommend [crontab guru](https://crontab.guru/) if you're new at setting up cron jobs.
+
+    0 * * * * cd /home/ncov && Rscript script.R
+All set!
+
+Though every version should be backward compatible, it’s a good practice to re-run a crawl after installing a new version of the package.
+### Data Corrections
+Below is a list of corrected inaccuracies pertaining to the datasets used:
+
+`v0.1.1`
+
+-   There was an issue were the number of cases counted in the John Hopkins map of china and world map was wrongly filtered and gave numbers higher than actually are.
+
+`v0.0.6`
+
+-   Corrected death rate from `deaths/confirmed` to `deaths/(confirmed + recovered)`
+
+`v0.0.3`:
+
+-   Deaths and recovered numbers for DingXiangYuan data was previously [swapped](https://github.com/JohnCoene/coronavirus/issues/2), now fixed.
+-   Number of suspected by city given by DingXiangYuan is wildly inaccurate, has been removed.
+-   Replaced Map on JHU tab as color scaling was inaccurate due to timeline.

--- a/INFORMATION.md
+++ b/INFORMATION.md
@@ -13,7 +13,7 @@
 
 Dashboard to track the spread of the coronavirus, based on three data sources, built with [shinyMobile](https://rinterface.github.io/shinyMobile/) and [echarts4r](https://echarts4r.john-coene.com/).
 
-[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFO.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
+[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFORMATION.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
 
 </div>
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,21 @@
-YEAR: 2020
-COPYRIGHT HOLDER: John Coene
+# MIT License
+
+Copyright (c) 2020 John Coene
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 
 Dashboard to track the spread of the coronavirus, based on three data sources, built with [shinyMobile](https://rinterface.github.io/shinyMobile/) and [echarts4r](https://echarts4r.john-coene.com/).
 
-[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFO.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
+[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFORMATION.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
 
 </div>
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,69 +1,93 @@
-# coronavirus 0.1.4
 
-- Updated JHU data source, no longer provides recovered data
+<div align="center">
 
-# coronavirus 0.1.3
+<img src="./man/figures/logo.png" height="250px" />
 
-- Meet new country naming convention of John Hopkins data.
-- Added, in jhu tab, click on country to narrow down trend
+<!-- badges: start -->
+[![CircleCI build status](https://circleci.com/gh/JohnCoene/coronavirus.svg?style=svg)](https://circleci.com/gh/JohnCoene/coronavirus)
+[![Travis build status](https://travis-ci.org/JohnCoene/coronavirus.svg?branch=master)](https://travis-ci.org/JohnCoene/coronavirus)
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/JohnCoene/coronavirus?branch=master&svg=true)](https://ci.appveyor.com/project/JohnCoene/coronavirus)
+![R-CMD-check](https://github.com/JohnCoene/coronavirus/workflows/R-CMD-check/badge.svg)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://www.tidyverse.org/lifecycle/#stable)
+![](https://img.shields.io/badge/license-MIT-blue)
+<!-- badges: end -->
 
-# coronavirus 0.1.2
+Dashboard to track the spread of the coronavirus, based on three data sources, built with [shinyMobile](https://rinterface.github.io/shinyMobile/) and [echarts4r](https://echarts4r.john-coene.com/).
 
-- Added news tab
-- Added daily cases to JHU tab
-- Added line graph of cases outside China
-- Added cumulative view on new cases in JHU tab
-- Improve chart transition
+[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFO.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
 
-# coronavirus 0.1.1
+</div>
 
-- Initialise embeds; ability to embed charts, optionally.
-- Corrected JHU maps.
-- Changed JHU China map to piecewise visual map
-- Changed DXY maps to piecewise
+## Change Log
+Below is a complete version history of the **coronavirus** package and the main changes within each version.
 
-# coronavirus 0.1.0
 
-- Initialise API, see `run_api`
+### [coronavirus 0.1.4](https://coronavirus.john-coene.com/#/news?id=coronavirus-014)
 
-# coronavirus 0.0.6
+-   Updated JHU data source, no longer provides recovered data
 
-- Add total numbers as returned by Weixin. :warning: great discrepancy between those and the daily figures.
-- Fixed to meet new John Hopkins data format.
-- PWA works on iPhone
+### [coronavirus 0.1.3](https://coronavirus.john-coene.com/#/news?id=coronavirus-013)
 
-# coronavirus 0.0.5
+-   Meet new country naming convention of John Hopkins data.
+-   Added, in jhu tab, click on country to narrow down trend
 
-- Add hubei default province in DXY tab.
-- Add shinyscroll to scroll to selected province in DXY tab.
-- Extend toast duration to 5 seconds.
-- Remove coordinates of cities from crawl.
-- Switch to using [Github](https://github.com/CSSEGISandData/2019-nCoV) instead of spreadsheet for JHU data.
-- Add death rate and plot to JHU dashboard
-- Added icons, thanks to Victor Perrier
+### [coronavirus 0.1.2](https://coronavirus.john-coene.com/#/news?id=coronavirus-012)
 
-# coronavirus 0.0.4
+-   Added news tab
+-   Added daily cases to JHU tab
+-   Added line graph of cases outside China
+-   Added cumulative view on new cases in JHU tab
+-   Improve chart transition
 
-- Revamped DXY tab, uses counties and provinces instead of geo-located cities.
-- John Hopkins added timeline bar chart.
-- Added `create_script` to easily create cronjob script.
-- Use translation as internal dataset instead of utils data.frame due to encoding issue see [#6](https://github.com/JohnCoene/coronavirus/issues/6).
-- Force Shiny version `1.4.0`, see [#6](https://github.com/JohnCoene/coronavirus/issues/6).
-- Improve loader on DXY city map
+### [coronavirus 0.1.1](https://coronavirus.john-coene.com/#/news?id=coronavirus-011)
 
-# coronavirus 0.0.3
+-   Initialise embeds; ability to embed charts, optionally.
+-   Corrected JHU maps.
+-   Changed JHU China map to piecewise visual map
+-   Changed DXY maps to piecewise
 
-- Connect all charts in dxy and weixin tabs
-- Corrected deaths and recovered in DingXiangYuan data, was swapped, see [#2](https://github.com/JohnCoene/coronavirus/issues/2)
-- Number of suspected by city given by DingXiangYuan is wildly inaccurate, has been removed.
-- JHU timeline uses time scale for better, more accurate representation of events.
-- Corrected legend on timeline in JHU tab
+### [coronavirus 0.1.0](https://coronavirus.john-coene.com/#/news?id=coronavirus-010)
 
-# coronavirus 0.0.2
+-   Initialise API, see `run_api`
 
-- Added DXY data source and corresponding tab
-- Corrected Timeline map dates on JHU map
+### [coronavirus 0.0.6](https://coronavirus.john-coene.com/#/news?id=coronavirus-006)
 
-# coronavirus 0.0.1
+-   Add total numbers as returned by Weixin; great discrepancy between those and the daily figures.
+-   Fixed to meet new John Hopkins data format.
+-   PWA works on iPhone
 
-* Initial version
+### [coronavirus 0.0.5](https://coronavirus.john-coene.com/#/news?id=coronavirus-005)
+
+-   Add hubei default province in DXY tab.
+-   Add shinyscroll to scroll to selected province in DXY tab.
+-   Extend toast duration to 5 seconds.
+-   Remove coordinates of cities from crawl.
+-   Switch to using [Github](https://github.com/CSSEGISandData/2019-nCoV) instead of spreadsheet for JHU data.
+-   Add death rate and plot to JHU dashboard
+-   Added icons, thanks to Victor Perrier
+
+### [coronavirus 0.0.4](https://coronavirus.john-coene.com/#/news?id=coronavirus-004)
+
+-   Revamped DXY tab, uses counties and provinces instead of geo-located cities.
+-   John Hopkins added timeline bar chart.
+-   Added `create_script` to easily create cronjob script.
+-   Use translation as internal dataset instead of utils data.frame due to encoding issue see [#6](https://github.com/JohnCoene/coronavirus/issues/6).
+-   Force Shiny version `1.4.0`, see [#6](https://github.com/JohnCoene/coronavirus/issues/6).
+-   Improve loader on DXY city map
+
+### [coronavirus 0.0.3](https://coronavirus.john-coene.com/#/news?id=coronavirus-003)
+
+-   Connect all charts in dxy and weixin tabs
+-   Corrected deaths and recovered in DingXiangYuan data, was swapped, see [#2](https://github.com/JohnCoene/coronavirus/issues/2)
+-   Number of suspected by city given by DingXiangYuan is wildly inaccurate, has been removed.
+-   JHU timeline uses time scale for better, more accurate representation of events.
+-   Corrected legend on timeline in JHU tab
+
+### [coronavirus 0.0.2](https://coronavirus.john-coene.com/#/news?id=coronavirus-002)
+
+-   Added DXY data source and corresponding tab
+-   Corrected Timeline map dates on JHU map
+
+### [coronavirus 0.0.1](https://coronavirus.john-coene.com/#/news?id=coronavirus-001)
+
+-   Initial version

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Dashboard to track the spread of the coronavirus, based on three data sources, built with [shinyMobile](https://rinterface.github.io/shinyMobile/) and [echarts4r](https://echarts4r.john-coene.com/).
 
-[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFO.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
+[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFORMATION.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <div align="center">
 
 <img src="./man/figures/logo.png" height="250px" />
@@ -13,32 +14,21 @@
 
 Dashboard to track the spread of the coronavirus, based on three data sources, built with [shinyMobile](https://rinterface.github.io/shinyMobile/) and [echarts4r](https://echarts4r.john-coene.com/).
 
-[Tracker](https://shiny.john-coene.com/coronavirus) | [Docs](https://coronavirus.john-coene.com) | [API](https://coronavirus.john-coene.com/#/api) | [Changelog](NEWS.md)
+[Home](README.md) | [Tracker](https://shiny.john-coene.com/coronavirus) | [Getting Started](GETSTARTED.md) | [Information](INFO.md) | [Changelog](NEWS.md) | [Contribute](CONTRIBUTE.md)
 
 </div>
 
-## Test
+## About
 
-You can test the app before preparing any kind of deployment (e.g.: set up a database), visit the [docs](https://coronavirus.john-coene.com) if you want to deploy it.
+The Coronavirus Tracker tracks data from Johns Hopkins, Weixin (WeChat), and DingXiangYuan (DXY) on the Novel Coronavirus 2019 (COVID-19). The tracker sources a database that is refreshed every hour. The code for the tracker is written in R and optimized for mobile.
 
-```r
-library(coronavirus)
+The code for the tracker is open source and can be deployed locally. Please see the [instructions](GETSTARTED.md) on how to run the API on your own machine/sever.
 
-virus <- crawl_coronavirus()
-run_app(virus)
-```
-
-![](https://coronavirus.john-coene.com/_media/banner.png)
-
-## Get it
-
-You can view the [dashboard](https://shiny.john-coene.com/coronavirus) online or download the package to run it locally or deploy it.
-
-``` r
-# install.packages("remotes")
-remotes::install_github("JohnCoene/coronavirus")
-```
-
-## Contribute
-
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this project, you agree to abide by its terms.
+Please use the links in the navigation bar immediately above this section for more information on this project, including how to contribute and getting started with your own iteration.
+## Features
+You can visit the live tracker at [**shiny.john-coene.com/coronavirus**](https://shiny.john-coene.com/coronavirus/). The app is optimized for mobile.
+![](https://coronavirus.john-coene.com/_media/banner.png)The app features a wide array of graphs and maps to view and analyze datasets frin Johns Hopkinsm Weixin, and DXY. It also features a great deal of interactive data visualization:
+#### Ex. Timeline of Confirmed Cases by Province in China
+![](https://coronavirus.john-coene.com/_media/coronavirus_time1.gif)
+#### Ex. Province and City Breakdown
+![](https://coronavirus.john-coene.com/_media/coronavirus_time2.gif)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The code for the tracker is open source and can be deployed locally. Please see 
 Please use the links in the navigation bar immediately above this section for more information on this project, including how to contribute and getting started with your own iteration.
 ## Features
 You can visit the live tracker at [**shiny.john-coene.com/coronavirus**](https://shiny.john-coene.com/coronavirus/). The app is optimized for mobile.
-![](https://coronavirus.john-coene.com/_media/banner.png)The app features a wide array of graphs and maps to view and analyze datasets frin Johns Hopkinsm Weixin, and DXY. It also features a great deal of interactive data visualization:
+![](https://coronavirus.john-coene.com/_media/banner.png)The app features a wide array of graphs and maps to view and analyze datasets from Johns Hopkins, Weixin, and DXY. It also features a great deal of interactive data visualization:
 #### Ex. Timeline of Confirmed Cases by Province in China
 ![](https://coronavirus.john-coene.com/_media/coronavirus_time1.gif)
 #### Ex. Province and City Breakdown


### PR DESCRIPTION
I've added new documentation for the project. 

**Why**
I found the bulk of the project information was found on the tracker site and not on Github. I translated that information into new .md files for the repo with the intent on providing prospective contributors pertinent information about the project, all consolidated into one place.

**What**

README.md
- Added a new navigation bar with links to the Tracker website, a section on how to deploy your own instance of the app, an information page with detail specifics on the app, the changelog, and a page on how to contribute to the project.
- Established a clear "About" section that communicates the purpose of the app and how to navigate through the information portion of the repo
- Created a section on different features of the app (information is pulled from [ here](https://coronavirus.john-coene.com/#/tracker))

GETSTARTED.md
- Details how to deploy the application
- Describes dependencies and required external tools
- Information is pulled from [here](https://coronavirus.john-coene.com/#/get-started?id=install).

INFORMATION.md
- Provides information on the data used in the app
- Gives instruction on how to embed charts
- Information is pulled from [here](https://coronavirus.john-coene.com/#/data) and [here](https://coronavirus.john-coene.com/#/embeds).

CONTRIBUTE.md
- These contributing guidelines and processes are inferred based on the coding style used and closed pull requests.
- Instructs prospective contributors on how to contribute to the project
- Links to to [Contributor Code of Conduct](https://github.com/JohnCoene/coronavirus/blob/master/CODE_OF_CONDUCT.md)
- Links to [Google's R coding style guide](http://web.stanford.edu/class/cs109l/unrestricted/resources/google-style.html)
- Lists the project's license